### PR TITLE
Resolves issue 18: json file content utf-8 not load real string

### DIFF
--- a/bigjson/filereader.py
+++ b/bigjson/filereader.py
@@ -7,7 +7,7 @@ class FileReader:
     _WHITESPACE = b'\t\n\r '
     _READBUF_CHUNK_SIZE = 1024*1024
 
-    def __init__(self, file, encoding):
+    def __init__(self, file, encoding="utf-8"):
         self.file = file
         # TODO: Support encodings where basic shortest characters are longer than one byte (e.g. UTF-16 and UTF-32)!
         self.encoding = encoding
@@ -206,7 +206,10 @@ class FileReader:
         read_amount = max(minimum_left, FileReader._READBUF_CHUNK_SIZE) - (len(self.readbuf) - self.readbuf_read)
         self.readbuf_pos += self.readbuf_read
         old_pos = self.file.tell()
-        self.readbuf = self.readbuf[self.readbuf_read:] + self.file.read(read_amount)
+        read_in = self.file.read(read_amount)
+        if not isinstance(read_in, bytes):
+            read_in = read_in.encode(self.encoding)
+        self.readbuf = self.readbuf[self.readbuf_read:] + read_in
         self.readbuf_read = 0
 
     def _tell_read_pos(self):

--- a/tests/test_crlf_line_terminators.py
+++ b/tests/test_crlf_line_terminators.py
@@ -7,13 +7,27 @@ import bigjson
 DATA_JSON_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'crlf_data.json')
 
 
+def _load_data(self, mode):
+    if mode == "r":
+        file_in =  open(DATA_JSON_PATH, mode, encoding="utf-8")
+    else:
+        file_in =  open(DATA_JSON_PATH, mode)
+
+    json_obj = bigjson.load(file_in, encoding='utf-8')
+    file_in.close()
+    return json_obj
+
+
 class TestCrlfLineTerminators(TestCase):
 
-    def test_crlf_line_terminators(self):
+    def test_crlf_line_terminators_rb(self):
+        json_obj = _load_data(self, "rb")
+        self.assertEqual(len(json_obj['nested_list1']), 2)
+        self.assertEqual(len(json_obj['nested_list1'][0]['sub_nested_arr1']), 2)
+        self.assertEqual(json_obj['nested_list1'][0]['sub_nested_arr1'][0]['ssn_1'], 'v1')
 
-        file_in = open(DATA_JSON_PATH, 'rb')
-        json_obj = bigjson.load(file_in, encoding='utf-8')
-
+    def test_crlf_line_terminators_r(self):
+        json_obj = _load_data(self, "r")
         self.assertEqual(len(json_obj['nested_list1']), 2)
         self.assertEqual(len(json_obj['nested_list1'][0]['sub_nested_arr1']), 2)
         self.assertEqual(json_obj['nested_list1'][0]['sub_nested_arr1'][0]['ssn_1'], 'v1')

--- a/tests/test_unicode_surrogates.py
+++ b/tests/test_unicode_surrogates.py
@@ -4,14 +4,36 @@ from unittest import TestCase
 import bigjson
 
 
-DATA_JSON_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'unicode_surrogates_data.json')
+SURROGATES_PATH = os.path.join(os.path.dirname(
+                               os.path.abspath(__file__)),
+                               "unicode_surrogates_data.json")
+ZHCN_PATH = os.path.join(os.path.dirname(
+                         os.path.abspath(__file__)), "unicode_zhcn.json")
 
 
 class TestUnicodeSurrogates(TestCase):
 
-    def test_unicode_surrogates(self):
-
-        with open(DATA_JSON_PATH, 'rb') as f:
+    def test_unicode_surrogates_rb(self):
+        with open(SURROGATES_PATH, "rb") as f:
             data = bigjson.load(f)
-            self.assertEqual(len(data), 1)
-            self.assertEqual(data[0], 'test\n𝄇"lol')
+            self.assertEqual(len(data), 2)
+            self.assertEqual(data[0], "test\n𝄇\"lol")
+            self.assertEqual(data[1],
+                             "Caretaker\u00e2\u20ac\u2122s accommodation")
+        with open(ZHCN_PATH, "rb") as zhf:
+            data = bigjson.load(zhf)
+            self.assertEqual(data["name"], "金牌综艺")
+            self.assertEqual(data["languages"][0]["name"], "Chinese")
+
+    def test_unicode_surrogates_r(self):
+        with open(SURROGATES_PATH, "r") as f:
+            data = bigjson.load(f)
+            self.assertEqual(len(data), 2)
+            self.assertEqual(data[0], "test\n𝄇\"lol")
+            self.assertEqual(data[1],
+                             "Caretaker\u00e2\u20ac\u2122s accommodation")
+        with open(ZHCN_PATH, "r") as zhf:
+            data = bigjson.load(zhf)
+            self.assertEqual(data["name"], "金牌综艺")
+            self.assertEqual(data["languages"][0]["name"], "Chinese")
+

--- a/tests/unicode_surrogates_data.json
+++ b/tests/unicode_surrogates_data.json
@@ -1,1 +1,1 @@
-["test\n\ud834\udd07\"lol"]
+["test\n\ud834\udd07\"lol", "Caretaker\u00e2\u20ac\u2122s accommodation"]

--- a/tests/unicode_zhcn.json
+++ b/tests/unicode_zhcn.json
@@ -1,0 +1,23 @@
+{
+  "name": "金牌综艺",
+  "logo": "https://parco-zh.github.io/demo/new3.png",
+  "url": "http://url.goes.here:8081/ysten-business/live/saishijx/1.m3u8",
+  "category": null,
+  "languages": [
+    {
+      "code": "zho",
+      "name": "Chinese"
+    }
+  ],
+  "countries": [
+    {
+      "code": "cn",
+      "name": "China"
+    }
+  ],
+  "tvg": {
+    "id": "JinPaiZongYi.cn",
+    "name": null,
+    "url": null
+  }
+}


### PR DESCRIPTION
The main change is in `_ensure_readbuf_left()` where we now check to see if the read-in chunk is bytes or str, and encodes if that's required. This avoids the "Cannot concat str to bytes" error that would occur previously.

I've update the CRLF and Unicode tests. The Unicode tests now include reading the file as 'r' and as 'rb', as well as adding my specific troublesome unicode and @testcomet's unicode example from Issue 18.